### PR TITLE
feat: Add support for building AWS Lambda artifacts

### DIFF
--- a/build.go
+++ b/build.go
@@ -2,6 +2,7 @@ package mage
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -89,21 +90,39 @@ func buildPlatformIterator(
 	platforms := strings.SplitSeq(envs.GetEnv("PLATFORMS", runtime.GOOS+"/"+runtime.GOARCH), ",")
 
 	for platform := range platforms {
-		ctp := helper.NewCommandTemplate(ct.Debug, ct.CommandDir)
-		ctp.AdditionalArtifacts = ct.AdditionalArtifacts
-		sp := strings.Split(platform, "/")
-		if len(sp) != 2 { //nolint:mnd // "os/arch"
-			continue
-		}
-		if after, ok := strings.CutPrefix(sp[1], "armv"); ok {
-			ctp.SetPlatform(sp[0], "arm", after)
-		} else {
-			ctp.SetPlatform(sp[0], sp[1], "")
+		var ctp *helper.CommandTemplate
+		{
+			var ctpErr error
+			ctp, ctpErr = buildPlatformCommandTemplate(ctx, ct, platform)
+			if ctpErr != nil {
+				err = multierr.Append(err, ctpErr)
+				continue
+			}
 		}
 		err = multierr.Append(err, f(ctx, ctp))
 	}
 
 	return err
+}
+
+func buildPlatformCommandTemplate(
+	_ context.Context,
+	ct *helper.CommandTemplate,
+	platform string,
+) (*helper.CommandTemplate, error) {
+	ctp := helper.NewCommandTemplate(ct.Debug, ct.CommandDir)
+	ctp.AdditionalArtifacts = ct.AdditionalArtifacts
+	ctp.CommandName = ct.CommandName
+	sp := strings.Split(platform, "/")
+	if len(sp) != 2 { //nolint:mnd // "os/arch"
+		return nil, fmt.Errorf("invalid platform: %s", platform)
+	}
+	if after, ok := strings.CutPrefix(sp[1], "armv"); ok {
+		ctp.SetPlatform(sp[0], "arm", after)
+	} else {
+		ctp.SetPlatform(sp[0], sp[1], "")
+	}
+	return ctp, nil
 }
 
 func buildArtifact(_ context.Context, ct *helper.CommandTemplate) error {

--- a/build_lambda.go
+++ b/build_lambda.go
@@ -1,0 +1,116 @@
+package mage
+
+import (
+	"archive/zip"
+	"context"
+	"io"
+	"os"
+
+	"github.com/dosquad/mage/dyndep"
+	"github.com/dosquad/mage/helper"
+	"github.com/dosquad/mage/helper/paths"
+	"github.com/dosquad/mage/loga"
+
+	"github.com/magefile/mage/mg"
+	"github.com/na4ma4/go-permbits"
+)
+
+// Lambda creates lambda artifacts.
+func (Build) Lambda(ctx context.Context) error {
+	// Lambda builds only support the following platforms.
+	_ = os.Setenv("PLATFORMS", "linux/arm64,linux/amd64")
+
+	dyndep.CtxDeps(ctx, dyndep.Build)
+	mg.CtxDeps(ctx, Build.Release)
+
+	pathList := paths.MustCommandPaths()
+
+	paths.MustMakeDir(paths.MustGetArtifactPath("lambda"), permbits.MustString("ug=rwx,o=rx"))
+
+	for _, cmdPath := range pathList {
+		ct := helper.NewCommandTemplate(false, cmdPath)
+		ct.AdditionalArtifacts = dyndep.GetArchiveSideloadDeps(ctx)
+		loga.PrintDebugf("ct.AdditionalArtifacts: %+v", ct.AdditionalArtifacts)
+
+		if err := buildPlatformIterator(ctx, ct, func(_ context.Context, ct *helper.CommandTemplate) error {
+			// buildArtifact(ctx, ct)
+			loga.PrintInfof("Create Archive for %s/%s (%s)",
+				ct.GoOS, ct.GoArch,
+				ct.OutputArtifact,
+			)
+
+			if err := buildLambdaZip(ctx, ct); err != nil {
+				return err
+			}
+
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func buildLambdaZip(ctx context.Context, ct *helper.CommandTemplate) error {
+	zipPath := paths.MustGetArtifactPath("lambda", ct.CommandName+"_"+ct.GoOS+"_"+ct.GoArch+".zip")
+	loga.PrintDebugf("buildLambdaZip(%s, %s, %s): %s", ct.CommandName, ct.GoOS, ct.GoArch, zipPath)
+
+	var srcFile *os.File
+	{
+		var err error
+		srcFile, err = os.Open(ct.OutputArtifact)
+		if err != nil {
+			return err
+		}
+		defer srcFile.Close()
+	}
+
+	var f *os.File
+	{
+		var err error
+		f, err = os.Create(zipPath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+	}
+
+	zipf := zip.NewWriter(f)
+	defer zipf.Close()
+
+	var bsFile io.Writer
+	{
+		var err error
+		bsFile, err = zipf.CreateHeader(lambdaZipHeader(ctx))
+		if err != nil {
+			return err
+		}
+	}
+
+	if _, err := io.Copy(bsFile, srcFile); err != nil {
+		return err
+	}
+
+	if err := zipf.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func lambdaZipHeader(_ context.Context) *zip.FileHeader {
+	h := &zip.FileHeader{
+		Name: "bootstrap",
+	}
+
+	// Define unix permissions for the file
+	mode := permbits.MustString("a=rx,u+w")
+
+	h.ExternalAttrs = uint32(mode) << 16 //nolint:mnd // Store permissions in the top 16 bits
+
+	//nolint:mnd // Set CreatorVersion to signal Unix attributes (3 << 8 represents Unix OS)
+	h.CreatorVersion = 3 << 8
+
+	return h
+}


### PR DESCRIPTION
* Add `build_lambda.go` to create AWS Lambda zip artifacts
* Update `build.go` to support building for Lambda platforms (linux/arm64, linux/amd64)
* Update `buildPlatformIterator` to handle platform-specific command templates
* Update `buildArtifact` to create zip files for Lambda deployment
* Update `lambdaZipHeader` to set correct permissions for Lambda bootstrap file
* Update `magefile` to include new Lambda build target